### PR TITLE
fix: allow actor creation

### DIFF
--- a/src/server/api/creation.ts
+++ b/src/server/api/creation.ts
@@ -28,9 +28,11 @@ export const creationRoutes = (cfg: APIConfig, store: Store, apsystem: ActivityP
   }, async (request, reply) => {
     const { actor } = request.params
 
-    const allowed = await apsystem.hasPermissionActorRequest(actor, request)
-    if (!allowed) {
-      return await reply.code(403).send('Not Allowed')
+    if (await store.admins.matches(actor)) {
+      const allowed = await apsystem.hasPermissionActorRequest(actor, request)
+      if (!allowed) {
+        return await reply.code(403).send('Not Allowed')
+      }
     }
 
     const info = request.body


### PR DESCRIPTION
Since the actor is about to be created, it doesn't exist on the database yet and we can't do a signed fetch in its name.