### PR TITLE
add tests for HTTP APIs and their routes

### DIFF
--- a/@types/http-signed-fetch.d.ts
+++ b/@types/http-signed-fetch.d.ts
@@ -1,0 +1,9 @@
+declare module 'http-signed-fetch' {
+  export function fetch (url: RequestInfo, init?: RequestInit & { publicKeyId: string, keypair: any }): Promise<Response>
+  export function create (fetchImplementation: typeof fetch): typeof fetch
+  export function generateKeypair (): {
+    publicKeyPem: string
+    privateKeyPem: string
+    publicKeyId: string
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,12 +33,16 @@
         "fastify-plugin": "^4.4.0",
         "fs": "0.0.1-security",
         "get-port": "^6.1.2",
+        "http-signed-fetch": "^1.0.1",
         "is-valid-hostname": "^1.0.2",
         "level": "^8.0.0",
         "make-dir": "^3.1.0",
         "nanoid": "^4.0.0",
         "prom-client": "^14.1.0",
         "yargs": "^17.6.2"
+      },
+      "bin": {
+        "distributed-press-social": "dist/bin.js"
       },
       "devDependencies": {
         "@ava/typescript": "^3.0.1",
@@ -3832,6 +3836,15 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/http-signed-fetch": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/http-signed-fetch/-/http-signed-fetch-1.0.1.tgz",
+      "integrity": "sha512-HSF8LDKJyjXSw//2fT2fcaOaiF28L5VbP92tHMlSpwkwnbfjcXJAZUU7d9NqaHD9FArF/NWgZQci2kdznFfSBA==",
+      "dependencies": {
+        "@digitalbazaar/http-digest-header": "^2.0.0",
+        "activitypub-http-signatures": "^2.0.1"
       }
     },
     "node_modules/human-signals": {

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "fastify-plugin": "^4.4.0",
     "fs": "0.0.1-security",
     "get-port": "^6.1.2",
+    "http-signed-fetch": "^1.0.1",
     "is-valid-hostname": "^1.0.2",
     "level": "^8.0.0",
     "make-dir": "^3.1.0",

--- a/src/client/README.md
+++ b/src/client/README.md
@@ -1,0 +1,190 @@
+## Social Inbox JavaScript Client Documentation
+
+## Overview
+
+The Social Inbox JavaScript Client is designed to facilitate interaction with the social inbox from JavaScript services and scripts. It offers a range of functionalities including managing actor information, admins, blocklists, allowlists, followers, hooks, and inbox and outbox activities.
+
+## Getting Started
+
+<!-- ### Installation
+
+```javascript
+// If the client is published as an NPM package
+npm install social-inbox-client
+
+// Or include it directly (if available as a standalone file)
+import { SocialInboxClient } from 'path/to/social-inbox-client'
+``` -->
+
+## Initialization
+
+```javascript
+import { SocialInboxClient } from "social-inbox-client";
+
+const client = new SocialInboxClient({
+  instance: "https://your.instance.url",
+  account: "yourAccount",
+  keypair: {
+    publicKeyPem: "yourPublicKeyPem",
+    privateKeyPem: "yourPrivateKeyPem",
+  },
+});
+```
+
+## Usage examples
+
+### Actor Information Management
+
+Fetch Actor Information
+
+```javascript
+const actorInfo = await client.getActorInfo("actorName");
+```
+
+Delete an Actor
+
+```javascript
+await client.deleteActor("actorName");
+```
+
+### Admin Management
+
+List Admins
+
+```javascript
+const admins = await client.listAdmins();
+```
+
+Add Admins
+
+```javascript
+await client.addAdmins(["admin1@example.com", "admin2@example.com"]);
+```
+
+Remove Admins
+
+```javascript
+await client.removeAdmins(["admin1@example.com"]);
+```
+
+### Blocklist Management
+
+Fetch Global Blocklist
+
+```javascript
+const blocklist = await client.getGlobalBlocklist();
+```
+
+Add to Blocklist
+
+```javascript
+await client.addGlobalBlocklist(["user1@example.com"]);
+```
+
+Remove from Blocklist
+
+```javascript
+await client.removeGlobalBlocklist(["user1@example.com"]);
+```
+
+### Allowlist Management
+
+Fetch Global Allowlist
+
+```javascript
+const allowlist = await client.getGlobalAllowlist();
+```
+
+Add to Allowlist
+
+```javascript
+await client.addGlobalAllowlist(["user2@example.com"]);
+```
+
+Remove from Allowlist
+
+```javascript
+await client.removeGlobalAllowlist(["user2@example.com"]);
+```
+
+### Follower Management
+
+List Followers
+
+```javascript
+const followers = await client.listFollowers("actorName");
+```
+
+Remove a Follower
+
+```javascript
+await client.removeFollower("actorName", "follower@example.com");
+```
+
+### Hook Management
+
+Set a Hook
+
+```javascript
+const hook = {
+  url: "https://webhook.endpoint",
+  secret: "yourSecret",
+};
+await client.setHook("actorName", "hookType", hook);
+```
+
+Fetch a Hook
+
+```javascript
+const existingHook = await client.getHook("actorName", "hookType");
+```
+
+Delete a Hook
+
+```javascript
+await client.deleteHook("actorName", "hookType");
+```
+
+### Inbox Management
+
+Fetch Inbox
+
+```javascript
+const inboxItems = await client.fetchInbox("actorName");
+```
+
+Post to Inbox
+
+```javascript
+const activity = {
+  type: "Note",
+  content: "Hello world",
+};
+await client.postToInbox("actorName", activity);
+```
+
+Approve an Inbox Item
+
+```javascript
+await client.approveInboxItem("actorName", "itemId");
+```
+
+Reject an Inbox Item
+
+```javascript
+await client.rejectInboxItem("actorName", "itemId");
+```
+
+### Outbox Management
+
+Post to Outbox
+
+```javascript
+await client.postToOutbox("actorName", activity);
+```
+
+Fetch an Outbox Item
+
+```javascript
+const outboxItem = await client.fetchOutboxItem("actorName", "itemId");
+```

--- a/src/client/README.md
+++ b/src/client/README.md
@@ -166,10 +166,18 @@ const inboxItems = await client.fetchInbox("actorName");
 
 Post to Inbox
 
+For more details on the ActivityPub Activity format, refer to the [official ActivityPub documentation](https://www.w3.org/TR/activitypub/#activities).
+
 ```javascript
 const activity = {
-  type: "Note",
-  content: "Hello world",
+  '@context': 'https://www.w3.org/ns/activitystreams',
+  type: 'Create',
+  actor: 'https://example.com/user1',
+  object: {
+    type: 'Note',
+    content: 'Hello world',
+    id: 'https://example.com/note1'
+  }
 };
 await client.postToInbox("actorName", activity);
 ```

--- a/src/client/README.md
+++ b/src/client/README.md
@@ -136,7 +136,10 @@ Set a Hook
 ```javascript
 const hook = {
   url: "https://webhook.endpoint",
-  secret: "yourSecret",
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json"
+  }
 };
 await client.setHook("actorName", "hookType", hook);
 ```

--- a/src/client/README.md
+++ b/src/client/README.md
@@ -23,7 +23,7 @@ import { SocialInboxClient } from "social-inbox-client";
 
 const client = new SocialInboxClient({
   instance: "https://your.instance.url",
-  account: "yourAccount",
+  account: "@yourAccount@yourdomain",
   keypair: {
     publicKeyPem: "yourPublicKeyPem",
     privateKeyPem: "yourPrivateKeyPem",
@@ -38,7 +38,7 @@ const client = new SocialInboxClient({
 Fetch Actor Information
 
 ```javascript
-const actorInfo = await client.getActorInfo("actorName");
+const actorInfo = await client.getActorInfo("@actor@domain");
 ```
 
 Delete an Actor

--- a/src/client/README.md
+++ b/src/client/README.md
@@ -51,6 +51,8 @@ await client.deleteActor("actorName");
 
 List Admins
 
+Returns the global blocklist as an array of strings, each in the format `@username@domain`.
+
 ```javascript
 const admins = await client.listAdmins();
 ```
@@ -70,6 +72,8 @@ await client.removeAdmins(["admin1@example.com"]);
 ### Blocklist Management
 
 Fetch Global Blocklist
+
+Returns the global blocklist as an array of strings, each in the format `@username@domain`.
 
 ```javascript
 const blocklist = await client.getGlobalBlocklist();
@@ -91,6 +95,8 @@ await client.removeGlobalBlocklist(["user1@example.com"]);
 
 Fetch Global Allowlist
 
+Returns the global allowlist as an array of strings, each in the format `@username@domain`.
+
 ```javascript
 const allowlist = await client.getGlobalAllowlist();
 ```
@@ -110,6 +116,8 @@ await client.removeGlobalAllowlist(["user2@example.com"]);
 ### Follower Management
 
 List Followers
+
+Lists the followers of a specified actor, returning them in an array of strings in the format `@username@domain`.
 
 ```javascript
 const followers = await client.listFollowers("actorName");

--- a/src/client/index.test.ts
+++ b/src/client/index.test.ts
@@ -1,0 +1,172 @@
+import test from 'ava'
+import sinon from 'sinon'
+import { SocialInboxClient } from './index'
+
+const instance = 'https://test.instance'
+const account = 'testAccount'
+const keypair = {
+  publicKeyPem: 'mockPublicKey',
+  privateKeyPem: 'mockPrivateKey'
+}
+const mockFetch = sinon.stub()
+
+const client = new SocialInboxClient({ instance, account, keypair, fetch: mockFetch })
+
+// Reset mocks before each test
+test.beforeEach(() => {
+  mockFetch.reset()
+})
+
+test('Actor Info Management', async t => {
+  const mockActorInfo = { name: 'Test Actor', inbox: 'https://test.instance/inbox' }
+
+  // Mock Fetch Actor Info
+  mockFetch.withArgs(`${instance}/v1/testActor/`, sinon.match.any).resolves(new Response(JSON.stringify(mockActorInfo)))
+
+  // Mock Delete Actor
+  mockFetch.withArgs(`${instance}/v1/testActor/`, sinon.match({ method: 'DELETE' })).resolves(new Response())
+
+  const actorInfo = await client.getActorInfo('testActor')
+  t.deepEqual(actorInfo, mockActorInfo)
+
+  await t.notThrowsAsync(async () => {
+    await client.deleteActor('testActor')
+  })
+})
+
+test('Admin Management', async t => {
+  // Mock List Admins
+  mockFetch.withArgs(`${instance}/v1/admins`, sinon.match.any).resolves(new Response('admin1\nadmin2'))
+
+  // Mock Add Admins
+  mockFetch.withArgs(`${instance}/v1/admins`, sinon.match({ method: 'POST' })).resolves(new Response())
+
+  // Mock Remove Admins
+  mockFetch.withArgs(`${instance}/v1/admins`, sinon.match({ method: 'DELETE' })).resolves(new Response())
+
+  const list = await client.listAdmins()
+  t.deepEqual(list, ['admin1', 'admin2'])
+
+  await t.notThrowsAsync(async () => {
+    await client.addAdmins(['admin3'])
+  })
+
+  await t.notThrowsAsync(async () => {
+    await client.removeAdmins(['admin1'])
+  })
+})
+
+test('Blocklist Management', async t => {
+  // Mock Get Global Blocklist
+  mockFetch.withArgs(`${instance}/v1/blocklist`, sinon.match.any).resolves(new Response('blockedUser1\nblockedUser2'))
+
+  // Mock Add to Global Blocklist
+  mockFetch.withArgs(`${instance}/v1/blocklist`, sinon.match({ method: 'POST' })).resolves(new Response())
+
+  // Mock Remove from Global Blocklist
+  mockFetch.withArgs(`${instance}/v1/blocklist`, sinon.match({ method: 'DELETE' })).resolves(new Response())
+
+  const blocklist = await client.getGlobalBlocklist()
+  t.deepEqual(blocklist, ['blockedUser1', 'blockedUser2'])
+
+  await t.notThrowsAsync(async () => {
+    await client.addGlobalBlocklist(['blockedUser3'])
+  })
+
+  await t.notThrowsAsync(async () => {
+    await client.removeGlobalBlocklist(['blockedUser1'])
+  })
+})
+
+test('Allowlist Management', async t => {
+  // Mock Get Global Allowlist
+  mockFetch.withArgs(`${instance}/v1/allowlist`, sinon.match.any).resolves(new Response('allowedUser1\nallowedUser2'))
+
+  // Mock Add to Global Allowlist
+  mockFetch.withArgs(`${instance}/v1/allowlist`, sinon.match({ method: 'POST' })).resolves(new Response())
+
+  // Mock Remove from Global Allowlist
+  mockFetch.withArgs(`${instance}/v1/allowlist`, sinon.match({ method: 'DELETE' })).resolves(new Response())
+
+  const allowlist = await client.getGlobalAllowlist()
+  t.deepEqual(allowlist, ['allowedUser1', 'allowedUser2'])
+
+  await t.notThrowsAsync(async () => {
+    await client.addGlobalAllowlist(['allowedUser3'])
+  })
+
+  await t.notThrowsAsync(async () => {
+    await client.removeGlobalAllowlist(['allowedUser1'])
+  })
+})
+
+test('Follower Management', async t => {
+  const mockFollowers = ['follower1', 'follower2']
+  mockFetch.withArgs(`${instance}/v1/testActor/followers`, sinon.match.any).resolves(new Response(JSON.stringify(mockFollowers)))
+  mockFetch.withArgs(`${instance}/v1/testActor/followers/follower1`, sinon.match({ method: 'DELETE' })).resolves(new Response())
+
+  const followers = await client.listFollowers('testActor')
+  t.deepEqual(followers, mockFollowers)
+
+  await t.notThrowsAsync(async () => {
+    await client.removeFollower('testActor', 'follower1')
+  })
+})
+
+test('Hook Management', async t => {
+  const mockHook = { url: 'https://test.hook/endpoint', secret: 'secretKey' }
+
+  // Mock Get Hook
+  mockFetch.withArgs(`${instance}/v1/testActor/hooks/testHook`, sinon.match.any).resolves(new Response(JSON.stringify(mockHook)))
+
+  // Mock Set Hook
+  mockFetch.withArgs(`${instance}/v1/testActor/hooks/testHook`, sinon.match({ method: 'POST' })).resolves(new Response())
+
+  // Mock Delete Hook
+  mockFetch.withArgs(`${instance}/v1/testActor/hooks/testHook`, sinon.match({ method: 'DELETE' })).resolves(new Response())
+
+  const hook = await client.getHook('testActor', 'testHook')
+  t.deepEqual(hook, mockHook)
+
+  await t.notThrowsAsync(async () => {
+    await client.setHook('testActor', 'testHook', mockHook)
+  })
+
+  await t.notThrowsAsync(async () => {
+    await client.deleteHook('testActor', 'testHook')
+  })
+})
+
+test('Inbox Management', async t => {
+  const mockInboxItems = [{ type: 'Note', content: 'Hello world!' }]
+
+  // Mock Fetch Inbox
+  mockFetch.withArgs(`${instance}/v1/testActor/inbox`, sinon.match.any).resolves(new Response(JSON.stringify(mockInboxItems)))
+
+  // Mock Post to Inbox
+  mockFetch.withArgs(`${instance}/v1/testActor/inbox`, sinon.match({ method: 'POST' })).resolves(new Response())
+
+  const inboxItems = await client.fetchInbox('testActor')
+  t.deepEqual(inboxItems, mockInboxItems)
+
+  await t.notThrowsAsync(async () => {
+    await client.postToInbox('testActor', { type: 'Note', content: 'Test note' })
+  })
+})
+
+test('Outbox Management', async t => {
+  const mockOutboxItem = { type: 'Note', content: 'Test outbox note' }
+
+  // Mock Post to Outbox
+  mockFetch.withArgs(`${instance}/v1/testActor/outbox`, sinon.match({ method: 'POST' })).resolves(new Response())
+
+  // Mock Fetch Outbox Item
+  mockFetch.withArgs(`${instance}/v1/testActor/outbox/123`, sinon.match.any).resolves(new Response(JSON.stringify(mockOutboxItem)))
+
+  await t.notThrowsAsync(async () => {
+    await client.postToOutbox('testActor', { type: 'Note', content: 'Test note' })
+  })
+
+  const outboxItem = await client.fetchOutboxItem('testActor', '123')
+  t.deepEqual(outboxItem, mockOutboxItem)
+})

--- a/src/client/index.test.ts
+++ b/src/client/index.test.ts
@@ -115,22 +115,30 @@ test('Follower Management', async t => {
 })
 
 test('Hook Management', async t => {
-  const mockHook = { url: 'https://test.hook/endpoint', secret: 'secretKey' }
+  // Updated mockHook to explicitly set the method type
+  const mockHook = {
+    url: 'https://test.hook/endpoint',
+    method: 'POST' as 'POST', // Explicitly typing the method
+    headers: { 'Content-Type': 'application/json' }
+  }
 
   // Mock Get Hook
-  mockSignedFetch.withArgs(`${instance}/v1/testActor/hooks/testHook`, sinon.match.any).resolves(new Response(JSON.stringify(mockHook)))
+  mockSignedFetch.withArgs(`${instance}/v1/testActor/hooks/testHook`, sinon.match.any)
+    .resolves(new Response(JSON.stringify(mockHook)))
 
   // Mock Set Hook
-  mockSignedFetch.withArgs(`${instance}/v1/testActor/hooks/testHook`, sinon.match({ method: 'POST' })).resolves(new Response())
+  mockSignedFetch.withArgs(`${instance}/v1/testActor/hooks/testHook`, sinon.match({ method: 'PUT' }))
+    .resolves(new Response())
 
   // Mock Delete Hook
-  mockSignedFetch.withArgs(`${instance}/v1/testActor/hooks/testHook`, sinon.match({ method: 'DELETE' })).resolves(new Response())
+  mockSignedFetch.withArgs(`${instance}/v1/testActor/hooks/testHook`, sinon.match({ method: 'DELETE' }))
+    .resolves(new Response())
 
   const hook = await client.getHook('testActor', 'testHook')
   t.deepEqual(hook, mockHook)
 
   await t.notThrowsAsync(async () => {
-    await client.setHook('testActor', 'testHook', mockHook)
+    await client.setHook('testActor', 'testHook', mockHook.url, mockHook.method, mockHook.headers)
   })
 
   await t.notThrowsAsync(async () => {

--- a/src/client/index.test.ts
+++ b/src/client/index.test.ts
@@ -6,25 +6,26 @@ const instance = 'https://test.instance'
 const account = 'testAccount'
 const keypair = {
   publicKeyPem: 'mockPublicKey',
-  privateKeyPem: 'mockPrivateKey'
+  privateKeyPem: 'mockPrivateKey',
+  publicKeyId: 'mockPublicKeyId'
 }
-const mockFetch = sinon.stub()
+const mockSignedFetch = sinon.stub()
 
-const client = new SocialInboxClient({ instance, account, keypair, fetch: mockFetch })
+const client = new SocialInboxClient({ instance, account, keypair, fetch: mockSignedFetch })
 
 // Reset mocks before each test
 test.beforeEach(() => {
-  mockFetch.reset()
+  mockSignedFetch.reset()
 })
 
 test('Actor Info Management', async t => {
   const mockActorInfo = { name: 'Test Actor', inbox: 'https://test.instance/inbox' }
 
   // Mock Fetch Actor Info
-  mockFetch.withArgs(`${instance}/v1/testActor/`, sinon.match.any).resolves(new Response(JSON.stringify(mockActorInfo)))
+  mockSignedFetch.withArgs(`${instance}/v1/testActor/`, sinon.match.any).resolves(new Response(JSON.stringify(mockActorInfo)))
 
   // Mock Delete Actor
-  mockFetch.withArgs(`${instance}/v1/testActor/`, sinon.match({ method: 'DELETE' })).resolves(new Response())
+  mockSignedFetch.withArgs(`${instance}/v1/testActor/`, sinon.match({ method: 'DELETE' })).resolves(new Response())
 
   const actorInfo = await client.getActorInfo('testActor')
   t.deepEqual(actorInfo, mockActorInfo)
@@ -36,13 +37,13 @@ test('Actor Info Management', async t => {
 
 test('Admin Management', async t => {
   // Mock List Admins
-  mockFetch.withArgs(`${instance}/v1/admins`, sinon.match.any).resolves(new Response('admin1\nadmin2'))
+  mockSignedFetch.withArgs(`${instance}/v1/admins`, sinon.match.any).resolves(new Response('admin1\nadmin2'))
 
   // Mock Add Admins
-  mockFetch.withArgs(`${instance}/v1/admins`, sinon.match({ method: 'POST' })).resolves(new Response())
+  mockSignedFetch.withArgs(`${instance}/v1/admins`, sinon.match({ method: 'POST' })).resolves(new Response())
 
   // Mock Remove Admins
-  mockFetch.withArgs(`${instance}/v1/admins`, sinon.match({ method: 'DELETE' })).resolves(new Response())
+  mockSignedFetch.withArgs(`${instance}/v1/admins`, sinon.match({ method: 'DELETE' })).resolves(new Response())
 
   const list = await client.listAdmins()
   t.deepEqual(list, ['admin1', 'admin2'])
@@ -58,13 +59,13 @@ test('Admin Management', async t => {
 
 test('Blocklist Management', async t => {
   // Mock Get Global Blocklist
-  mockFetch.withArgs(`${instance}/v1/blocklist`, sinon.match.any).resolves(new Response('blockedUser1\nblockedUser2'))
+  mockSignedFetch.withArgs(`${instance}/v1/blocklist`, sinon.match.any).resolves(new Response('blockedUser1\nblockedUser2'))
 
   // Mock Add to Global Blocklist
-  mockFetch.withArgs(`${instance}/v1/blocklist`, sinon.match({ method: 'POST' })).resolves(new Response())
+  mockSignedFetch.withArgs(`${instance}/v1/blocklist`, sinon.match({ method: 'POST' })).resolves(new Response())
 
   // Mock Remove from Global Blocklist
-  mockFetch.withArgs(`${instance}/v1/blocklist`, sinon.match({ method: 'DELETE' })).resolves(new Response())
+  mockSignedFetch.withArgs(`${instance}/v1/blocklist`, sinon.match({ method: 'DELETE' })).resolves(new Response())
 
   const blocklist = await client.getGlobalBlocklist()
   t.deepEqual(blocklist, ['blockedUser1', 'blockedUser2'])
@@ -80,13 +81,13 @@ test('Blocklist Management', async t => {
 
 test('Allowlist Management', async t => {
   // Mock Get Global Allowlist
-  mockFetch.withArgs(`${instance}/v1/allowlist`, sinon.match.any).resolves(new Response('allowedUser1\nallowedUser2'))
+  mockSignedFetch.withArgs(`${instance}/v1/allowlist`, sinon.match.any).resolves(new Response('allowedUser1\nallowedUser2'))
 
   // Mock Add to Global Allowlist
-  mockFetch.withArgs(`${instance}/v1/allowlist`, sinon.match({ method: 'POST' })).resolves(new Response())
+  mockSignedFetch.withArgs(`${instance}/v1/allowlist`, sinon.match({ method: 'POST' })).resolves(new Response())
 
   // Mock Remove from Global Allowlist
-  mockFetch.withArgs(`${instance}/v1/allowlist`, sinon.match({ method: 'DELETE' })).resolves(new Response())
+  mockSignedFetch.withArgs(`${instance}/v1/allowlist`, sinon.match({ method: 'DELETE' })).resolves(new Response())
 
   const allowlist = await client.getGlobalAllowlist()
   t.deepEqual(allowlist, ['allowedUser1', 'allowedUser2'])
@@ -102,8 +103,8 @@ test('Allowlist Management', async t => {
 
 test('Follower Management', async t => {
   const mockFollowers = ['follower1', 'follower2']
-  mockFetch.withArgs(`${instance}/v1/testActor/followers`, sinon.match.any).resolves(new Response(JSON.stringify(mockFollowers)))
-  mockFetch.withArgs(`${instance}/v1/testActor/followers/follower1`, sinon.match({ method: 'DELETE' })).resolves(new Response())
+  mockSignedFetch.withArgs(`${instance}/v1/testActor/followers`, sinon.match.any).resolves(new Response(JSON.stringify(mockFollowers)))
+  mockSignedFetch.withArgs(`${instance}/v1/testActor/followers/follower1`, sinon.match({ method: 'DELETE' })).resolves(new Response())
 
   const followers = await client.listFollowers('testActor')
   t.deepEqual(followers, mockFollowers)
@@ -117,13 +118,13 @@ test('Hook Management', async t => {
   const mockHook = { url: 'https://test.hook/endpoint', secret: 'secretKey' }
 
   // Mock Get Hook
-  mockFetch.withArgs(`${instance}/v1/testActor/hooks/testHook`, sinon.match.any).resolves(new Response(JSON.stringify(mockHook)))
+  mockSignedFetch.withArgs(`${instance}/v1/testActor/hooks/testHook`, sinon.match.any).resolves(new Response(JSON.stringify(mockHook)))
 
   // Mock Set Hook
-  mockFetch.withArgs(`${instance}/v1/testActor/hooks/testHook`, sinon.match({ method: 'POST' })).resolves(new Response())
+  mockSignedFetch.withArgs(`${instance}/v1/testActor/hooks/testHook`, sinon.match({ method: 'POST' })).resolves(new Response())
 
   // Mock Delete Hook
-  mockFetch.withArgs(`${instance}/v1/testActor/hooks/testHook`, sinon.match({ method: 'DELETE' })).resolves(new Response())
+  mockSignedFetch.withArgs(`${instance}/v1/testActor/hooks/testHook`, sinon.match({ method: 'DELETE' })).resolves(new Response())
 
   const hook = await client.getHook('testActor', 'testHook')
   t.deepEqual(hook, mockHook)
@@ -141,10 +142,10 @@ test('Inbox Management', async t => {
   const mockInboxItems = [{ type: 'Note', content: 'Hello world!' }]
 
   // Mock Fetch Inbox
-  mockFetch.withArgs(`${instance}/v1/testActor/inbox`, sinon.match.any).resolves(new Response(JSON.stringify(mockInboxItems)))
+  mockSignedFetch.withArgs(`${instance}/v1/testActor/inbox`, sinon.match.any).resolves(new Response(JSON.stringify(mockInboxItems)))
 
   // Mock Post to Inbox
-  mockFetch.withArgs(`${instance}/v1/testActor/inbox`, sinon.match({ method: 'POST' })).resolves(new Response())
+  mockSignedFetch.withArgs(`${instance}/v1/testActor/inbox`, sinon.match({ method: 'POST' })).resolves(new Response())
 
   const inboxItems = await client.fetchInbox('testActor')
   t.deepEqual(inboxItems, mockInboxItems)
@@ -158,10 +159,10 @@ test('Outbox Management', async t => {
   const mockOutboxItem = { type: 'Note', content: 'Test outbox note' }
 
   // Mock Post to Outbox
-  mockFetch.withArgs(`${instance}/v1/testActor/outbox`, sinon.match({ method: 'POST' })).resolves(new Response())
+  mockSignedFetch.withArgs(`${instance}/v1/testActor/outbox`, sinon.match({ method: 'POST' })).resolves(new Response())
 
   // Mock Fetch Outbox Item
-  mockFetch.withArgs(`${instance}/v1/testActor/outbox/123`, sinon.match.any).resolves(new Response(JSON.stringify(mockOutboxItem)))
+  mockSignedFetch.withArgs(`${instance}/v1/testActor/outbox/123`, sinon.match.any).resolves(new Response(JSON.stringify(mockOutboxItem)))
 
   await t.notThrowsAsync(async () => {
     await client.postToOutbox('testActor', { type: 'Note', content: 'Test note' })

--- a/src/client/index.test.ts
+++ b/src/client/index.test.ts
@@ -169,13 +169,21 @@ test('Outbox Management', async t => {
   // Mock Post to Outbox
   mockSignedFetch.withArgs(`${instance}/v1/testActor/outbox`, sinon.match({ method: 'POST' })).resolves(new Response())
 
-  // Mock Fetch Outbox Item
-  mockSignedFetch.withArgs(`${instance}/v1/testActor/outbox/123`, sinon.match.any).resolves(new Response(JSON.stringify(mockOutboxItem)))
+  // Mock Fetch Outbox Item for default actor
+  mockSignedFetch.withArgs(`${instance}/v1/${account}/outbox/123`, sinon.match.any).resolves(new Response(JSON.stringify(mockOutboxItem)))
+
+  // Mock Fetch Outbox Item for a specific actor
+  mockSignedFetch.withArgs(`${instance}/v1/specificActor/outbox/123`, sinon.match.any).resolves(new Response(JSON.stringify(mockOutboxItem)))
 
   await t.notThrowsAsync(async () => {
     await client.postToOutbox('testActor', { type: 'Note', content: 'Test note' })
   })
 
-  const outboxItem = await client.fetchOutboxItem('testActor', '123')
-  t.deepEqual(outboxItem, mockOutboxItem)
+  // Test fetching outbox item for default actor
+  const defaultActorOutboxItem = await client.fetchOutboxItem('123')
+  t.deepEqual(defaultActorOutboxItem, mockOutboxItem)
+
+  // Test fetching outbox item for a specific actor
+  const specificActorOutboxItem = await client.fetchOutboxItem('123', 'specificActor')
+  t.deepEqual(specificActorOutboxItem, mockOutboxItem)
 })

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -19,10 +19,11 @@ const TYPE_JSON = 'application/json'
 const GET = 'GET'
 const POST = 'POST'
 const DELETE = 'DELETE'
+const PUT = 'PUT'
 
 const NEWLINE = '\n'
 
-type VALID_METHODS = typeof GET | typeof POST | typeof DELETE
+type VALID_METHODS = typeof GET | typeof POST | typeof PUT | typeof DELETE
 
 type VALID_TYPES = typeof TYPE_TEXT | typeof TYPE_JSON | typeof TYPE_LDJSON | undefined
 
@@ -66,6 +67,7 @@ export class SocialInboxClient {
     return response
   }
 
+  // Actorinfo
   async setActorInfo (actor: string, info: ActorInfo): Promise<void> {
     await this.sendRequest(POST, `/${actor}/`, TYPE_JSON, info)
   }
@@ -91,15 +93,25 @@ export class SocialInboxClient {
     return await this.deleteActor(this.account)
   }
 
-  async sendActorInbox (actor: string, activity: APActivity): Promise<void> {
-    await this.sendRequest(POST, `/${actor}/inbox`, TYPE_LDJSON, activity)
+  // Admins
+  async listAdmins (): Promise<string[]> {
+    const response = await this.sendRequest(GET, '/admins')
+    const text = await response.text()
+    return text.split(NEWLINE)
   }
 
+  async addAdmins (admins: string[]): Promise<void> {
+    await this.sendRequest(POST, '/admins', TYPE_TEXT, admins.join(NEWLINE))
+  }
+
+  async removeAdmins (admins: string[]): Promise<void> {
+    await this.sendRequest(DELETE, '/admins', TYPE_TEXT, admins.join(NEWLINE))
+  }
+
+  // blocklist
   async getGlobalBlocklist (): Promise<string[]> {
     const response = await this.sendRequest(GET, '/blocklist')
-
     const text = await response.text()
-
     return text.split(NEWLINE)
   }
 
@@ -109,5 +121,72 @@ export class SocialInboxClient {
 
   async removeGlobalBlocklist (list: string[]): Promise<void> {
     await this.sendRequest(POST, '/blocklist', TYPE_TEXT, list.join(NEWLINE))
+  }
+
+  // Allowlist
+  async getGlobalAllowlist (): Promise<string[]> {
+    const response = await this.sendRequest(GET, '/allowlist')
+    const text = await response.text()
+    return text.split(NEWLINE)
+  }
+
+  async addGlobalAllowlist (accounts: string[]): Promise<void> {
+    await this.sendRequest(POST, '/allowlist', TYPE_TEXT, accounts.join(NEWLINE))
+  }
+
+  async removeGlobalAllowlist (accounts: string[]): Promise<void> {
+    await this.sendRequest(DELETE, '/allowlist', TYPE_TEXT, accounts.join(NEWLINE))
+  }
+
+  // Followers
+  async listFollowers (actor: string): Promise<string[]> {
+    const response = await this.sendRequest(GET, `/${actor}/followers`)
+    return await response.json()
+  }
+
+  async removeFollower (actor: string, follower: string): Promise<void> {
+    await this.sendRequest(DELETE, `/${actor}/followers/${encodeURIComponent(follower)}`)
+  }
+
+  // Hooks
+  async getHook (actor: string, hookType: string): Promise<any> {
+    const response = await this.sendRequest(GET, `/${actor}/hooks/${hookType}`)
+    return await response.json()
+  }
+
+  async setHook (actor: string, hookType: string, hook: any): Promise<void> {
+    await this.sendRequest(PUT, `/${actor}/hooks/${hookType}`, TYPE_JSON, hook)
+  }
+
+  async deleteHook (actor: string, hookType: string): Promise<void> {
+    await this.sendRequest(DELETE, `/${actor}/hooks/${hookType}`)
+  }
+
+  // Inbox
+  async fetchInbox (actor: string): Promise<any> {
+    const response = await this.sendRequest(GET, `/${actor}/inbox`)
+    return await response.json()
+  }
+
+  async postToInbox (actor: string, activity: APActivity): Promise<void> {
+    await this.sendRequest(POST, `/${actor}/inbox`, TYPE_LDJSON, activity)
+  }
+
+  async approveInboxItem (actor: string, itemId: string): Promise<void> {
+    await this.sendRequest(POST, `/${actor}/inbox/${itemId}`)
+  }
+
+  async rejectInboxItem (actor: string, itemId: string): Promise<void> {
+    await this.sendRequest(DELETE, `/${actor}/inbox/${itemId}`)
+  }
+
+  // Outbox
+  async postToOutbox (actor: string, activity: APActivity): Promise<void> {
+    await this.sendRequest(POST, `/${actor}/outbox`, TYPE_LDJSON, activity)
+  }
+
+  async fetchOutboxItem (actor: string, itemId: string): Promise<APActivity> {
+    const response = await this.sendRequest(GET, `/${actor}/outbox/${itemId}`)
+    return await response.json()
   }
 }

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -15,6 +15,12 @@ export interface SocialInboxOptions {
   fetch?: SignedFetchLike
 }
 
+export interface Hook {
+  url: string
+  method: 'GET' | 'POST' | 'PUT' | 'DELETE'
+  headers: { [name: string]: string }
+}
+
 const TYPE_TEXT = 'text/plain'
 const TYPE_LDJSON = 'applicatin/ld+json'
 const TYPE_JSON = 'application/json'
@@ -158,7 +164,8 @@ export class SocialInboxClient {
     return await response.json()
   }
 
-  async setHook (actor: string, hookType: string, hook: any): Promise<void> {
+  async setHook (actor: string, hookType: string, url: string, method: 'GET' | 'POST' | 'PUT' | 'DELETE', headers: { [name: string]: string }): Promise<void> {
+    const hook = { url, method, headers }
     await this.sendRequest(PUT, `/${actor}/hooks/${hookType}`, TYPE_JSON, hook)
   }
 

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -59,14 +59,17 @@ export class SocialInboxClient {
 
     const finalContentType = contentType ?? TYPE_TEXT
 
+    // Extract publicKeyId from this.keypair
+    const { publicKeyId, ...keypairWithoutId } = this.keypair
+
     const response = await this.fetch(url, {
       method,
       headers: {
         'Content-Type': finalContentType
       },
       body,
-      publicKeyId: this.keypair.publicKeyId,
-      keypair: this.keypair
+      keypair: keypairWithoutId,
+      publicKeyId
     })
 
     if (!response.ok) {

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -199,7 +199,7 @@ export class SocialInboxClient {
     await this.sendRequest(POST, `/${actor}/outbox`, TYPE_LDJSON, activity)
   }
 
-  async fetchOutboxItem (actor: string, itemId: string): Promise<APActivity> {
+  async fetchOutboxItem (itemId: string, actor: string = this.account): Promise<APActivity> {
     const response = await this.sendRequest(GET, `/${actor}/outbox/${itemId}`)
     return await response.json()
   }

--- a/src/server/api/admins.test.ts
+++ b/src/server/api/admins.test.ts
@@ -1,0 +1,158 @@
+import test from 'ava'
+import fastify from 'fastify'
+import sinon from 'sinon'
+import { adminRoutes } from './admins'
+import Store from '../store/index.js'
+import ActivityPubSystem from '../apsystem.js'
+import { ModerationChecker } from '../moderation.js'
+import HookSystem from '../hooksystem'
+import { APIConfig } from '.'
+import { makeSigner } from '../../keypair.js'
+import { generateKeypair } from 'http-signed-fetch'
+
+const mockConfig: APIConfig = {
+  port: 3000,
+  host: 'localhost',
+  storage: 'path/to/storage',
+  publicURL: 'http://localhost:3000'
+}
+
+let server: any
+let mockStore: any
+let mockApsystem: any
+
+test.beforeEach(async () => {
+  server = fastify()
+  mockStore = sinon.createStubInstance(Store)
+
+  mockStore.admins = {
+    list: sinon.stub(),
+    add: sinon.stub(),
+    remove: sinon.stub()
+  }
+  mockStore.admins.list.resolves(['admin1@example.com', 'admin2@example.com'])
+  mockStore.admins.add.resolves()
+  mockStore.admins.remove.resolves()
+
+  mockApsystem = new ActivityPubSystem(mockConfig.publicURL, mockStore, new ModerationChecker(mockStore), new HookSystem(mockStore))
+  sinon.stub(mockApsystem, 'hasAdminPermissionForRequest').resolves(true)
+
+  await adminRoutes(mockConfig, mockStore, mockApsystem)(server)
+})
+
+const simulateSignedRequest = (method: string, path: string): { Signature: string, Date: string } => {
+  const keypair = generateKeypair()
+  const publicKeyId = 'https://example.com/#main-key'
+  const signer = makeSigner(keypair, publicKeyId)
+
+  const url = `${mockConfig.publicURL}${path}`
+
+  // Generate a signature header
+  const signatureHeader = signer.sign({
+    method,
+    url,
+    headers: {
+      host: 'localhost:3000',
+      date: new Date().toUTCString()
+    }
+  })
+
+  return {
+    Signature: signatureHeader,
+    Date: new Date().toUTCString()
+  }
+}
+
+test('GET /admins - success', async t => {
+  const signedHeaders = simulateSignedRequest('GET', '/admins')
+
+  mockApsystem.hasAdminPermissionForRequest.callsFake((request: any) => {
+    return 'Signature' in request.headers && 'Date' in request.headers
+  })
+
+  const response = await server.inject({
+    method: 'GET',
+    url: '/admins',
+    headers: signedHeaders
+  })
+
+  t.is(response.statusCode, 200)
+  t.is(response.body, 'admin1@example.com\nadmin2@example.com')
+})
+
+test('GET /admins - unauthorized', async t => {
+  mockApsystem.hasAdminPermissionForRequest.resolves(false)
+
+  const response = await server.inject({
+    method: 'GET',
+    url: '/admins'
+  })
+
+  t.is(response.statusCode, 403)
+})
+
+test('POST /admins - success', async t => {
+  const signedHeaders = simulateSignedRequest('POST', '/admins')
+
+  const response = await server.inject({
+    method: 'POST',
+    url: '/admins',
+    payload: 'newadmin@example.com',
+    headers: {
+      'Content-Type': 'text/plain',
+      ...signedHeaders
+    }
+  })
+
+  t.is(response.statusCode, 200)
+})
+
+test('POST /admins - unauthorized', async t => {
+  mockApsystem.hasAdminPermissionForRequest.resolves(false)
+
+  const response = await server.inject({
+    method: 'POST',
+    url: '/admins',
+    payload: 'newadmin@example.com',
+    headers: {
+      'Content-Type': 'text/plain'
+    }
+  })
+
+  t.is(response.statusCode, 403)
+})
+
+test('DELETE /admins - success', async t => {
+  const signedHeaders = simulateSignedRequest('DELETE', '/admins')
+
+  const response = await server.inject({
+    method: 'DELETE',
+    url: '/admins',
+    payload: 'admin1@example.com',
+    headers: {
+      'Content-Type': 'text/plain',
+      ...signedHeaders
+    }
+  })
+
+  t.is(response.statusCode, 200)
+})
+
+test('DELETE /admins - unauthorized', async t => {
+  mockApsystem.hasAdminPermissionForRequest.resolves(false)
+
+  const response = await server.inject({
+    method: 'DELETE',
+    url: '/admins',
+    payload: 'admin1@example.com',
+    headers: {
+      'Content-Type': 'text/plain'
+    }
+  })
+
+  t.is(response.statusCode, 403)
+})
+
+test.afterEach(async () => {
+  await server.close()
+})


### PR DESCRIPTION
Test failing issue:

✘ [fail]: server › api › admins › GET /admins - success
  ✔ server › api › admins › GET /admins - unauthorized (2.9s)
  ✘ [fail]: server › api › admins › POST /admins - success
  ✔ server › api › admins › POST /admins - unauthorized (1.2s)
  ✘ [fail]: server › api › admins › DELETE /admins - success
  ✔ server › api › admins › DELETE /admins - unauthorized

```
  server › api › admins › GET /admins - success

  src/server/api/admins.test.ts:79

   78:                                                                
   79:   t.is(response.statusCode, 200)                               
   80:   t.is(response.body, 'admin1@example.com\nadmin2@example.com')

  Difference (- actual, + expected):

  - 403
  + 200

  › file://src/server/api/admins.test.ts:79:5



  server › api › admins › POST /admins - success

  src/server/api/admins.test.ts:107

   106:                                 
   107:   t.is(response.statusCode, 200)
   108: })                              

  Difference (- actual, + expected):

  - 403
  + 200

  › file://src/server/api/admins.test.ts:107:5



  server › api › admins › DELETE /admins - success

  src/server/api/admins.test.ts:138

   137:                                 
   138:   t.is(response.statusCode, 200)
   139: })                              

  Difference (- actual, + expected):

  - 403
  + 200

  › file://src/server/api/admins.test.ts:138:5

  ─

  3 tests failed
```