### PR TITLE
Support undo activities, dont remove accepted inbox items

### DIFF
--- a/src/server/apsystem.ts
+++ b/src/server/apsystem.ts
@@ -341,10 +341,12 @@ export default class ActivityPubSystem {
 
     await actorStore.inbox.add(activity)
 
-    if (moderationState === BLOCKED) {
+    if (activityType === 'Undo') {
+      await this.performUndo(fromActor, activity)
+    } else if (moderationState === BLOCKED) {
     // TODO: Notify of blocks?
       await this.rejectActivity(fromActor, activityId)
-    } else if ((activityType === 'Undo') || (moderationState === ALLOWED)) {
+    } else if (moderationState === ALLOWED) {
       await this.approveActivity(fromActor, activityId)
     } else {
       await this.hookSystem.dispatchModerationQueued(fromActor, activity)

--- a/src/server/apsystem.ts
+++ b/src/server/apsystem.ts
@@ -326,6 +326,7 @@ export default class ActivityPubSystem {
     }
 
     const activityActor = activity.actor
+    const activityType = activity.type
 
     // TODO: handle array of string case and nested object
     if (typeof activityActor !== 'string') {
@@ -343,7 +344,7 @@ export default class ActivityPubSystem {
     if (moderationState === BLOCKED) {
     // TODO: Notify of blocks?
       await this.rejectActivity(fromActor, activityId)
-    } else if (moderationState === ALLOWED) {
+    } else if ((activityType === 'Undo') || (moderationState === ALLOWED)) {
       await this.approveActivity(fromActor, activityId)
     } else {
       await this.hookSystem.dispatchModerationQueued(fromActor, activity)

--- a/src/server/apsystem.ts
+++ b/src/server/apsystem.ts
@@ -362,10 +362,10 @@ export default class ActivityPubSystem {
     // TODO: Handle other types + index by post
     if (type === 'Follow') {
       await this.acceptFollow(fromActor, activity)
+      await this.hookSystem.dispatchOnApproved(fromActor, activity)
     } else if (type === 'Undo') {
       await this.performUndo(fromActor, activity)
     }
-    await this.hookSystem.dispatchOnApproved(fromActor, activity)
   }
 
   async rejectActivity (fromActor: string, activityId: string): Promise<void> {
@@ -409,6 +409,7 @@ export default class ActivityPubSystem {
       throw createError(400, 'Undo can only point to activities by same author')
     }
     await inbox.remove(object)
+    await this.hookSystem.dispatchOnApproved(fromActor, activity)
 
     // Detect if follow
     if (existing.type === 'Follow') {


### PR DESCRIPTION
- fixed a bug where rejected follows were actually accepted
- accepted activities no longer get removed
- added code path for Undo activities
 - checks that the same author that made the activity made the undo activity
 - removes the activity from the inbox
 - if it was a follow request, removes it.