### PR TITLE
feat: announcements profile is automated, so it's a service

### DIFF
--- a/src/server/announcements.ts
+++ b/src/server/announcements.ts
@@ -41,7 +41,7 @@ export class Announcements {
       ],
       // https://www.w3.org/TR/activitystreams-vocabulary/#actor-types
       id: this.actorUrl,
-      type: 'Person',
+      type: 'Service',
       name: 'Announcements',
       summary: `Announcements for ${new URL(this.actorUrl).hostname}`,
       preferredUsername: 'announcements',


### PR DESCRIPTION
mastodon will show the profile as "automated" with a robot icon