### PR TITLE
Swallow follower resolve errors, allow reading follower count unauthed

### DIFF
--- a/src/server/api/followers.ts
+++ b/src/server/api/followers.ts
@@ -23,13 +23,7 @@ export const followerRoutes = (cfg: APIConfig, store: Store, apsystem: ActivityP
   }, async (request, reply) => {
     const { actor } = request.params
     const allowed = await apsystem.hasPermissionActorRequest(actor, request)
-    const collection = await apsystem.followersCollection(actor)
-
-    // Allow seeing follower count but not followers
-    // TODO: Allow list to be public?
-    if (!allowed) {
-      delete collection.items
-    }
+    const collection = await apsystem.followersCollection(actor, !allowed)
 
     return await reply.send(collection)
   })

--- a/src/server/api/followers.ts
+++ b/src/server/api/followers.ts
@@ -23,11 +23,14 @@ export const followerRoutes = (cfg: APIConfig, store: Store, apsystem: ActivityP
   }, async (request, reply) => {
     const { actor } = request.params
     const allowed = await apsystem.hasPermissionActorRequest(actor, request)
+    const collection = await apsystem.followersCollection(actor)
+
+    // Allow seeing follower count but not followers
+    // TODO: Allow list to be public?
     if (!allowed) {
-      return await reply.code(403).send('Not Allowed')
+      delete collection.items
     }
 
-    const collection = await apsystem.followersCollection(actor)
     return await reply.send(collection)
   })
 

--- a/src/server/apsystem.ts
+++ b/src/server/apsystem.ts
@@ -494,18 +494,20 @@ export default class ActivityPubSystem {
     const followers = await actorStore.followers.list()
     const totalItems = followers.length
 
-    const items = countOnly ? undefined : (await Promise.all(
-      followers.map(async (mention) => {
-        try {
-          const url = await this.mentionToActor(mention)
-          return url
-        } catch {
-          // If we can't resolve them just don't show them
-          return ''
-        }
-      })
-      // Filter out failed loads
-    )).filter((item) => item.length !== 0)
+    const items = countOnly
+      ? undefined
+      : (await Promise.all(
+          followers.map(async (mention) => {
+            try {
+              const url = await this.mentionToActor(mention)
+              return url
+            } catch {
+              // If we can't resolve them just don't show them
+              return ''
+            }
+          })
+          // Filter out failed loads
+        )).filter((item) => item.length !== 0)
 
     return {
       '@context': 'https://www.w3.org/ns/activitystreams',

--- a/src/server/apsystem.ts
+++ b/src/server/apsystem.ts
@@ -480,7 +480,7 @@ export default class ActivityPubSystem {
     await this.sendTo(followerURL, fromActor, response)
   }
 
-  async followersCollection (fromActor: string): Promise<APCollection> {
+  async followersCollection (fromActor: string, countOnly: boolean = false): Promise<APCollection> {
     const actorStore = this.store.forActor(fromActor)
     const actorURL = await this.mentionToActor(fromActor)
 
@@ -492,8 +492,9 @@ export default class ActivityPubSystem {
     }
 
     const followers = await actorStore.followers.list()
+    const totalItems = followers.length
 
-    const items = (await Promise.all(
+    const items = countOnly ? undefined : (await Promise.all(
       followers.map(async (mention) => {
         try {
           const url = await this.mentionToActor(mention)
@@ -511,7 +512,7 @@ export default class ActivityPubSystem {
       type: 'OrderedCollection',
       id: followersURL,
       items,
-      totalItems: followers.length
+      totalItems
     }
   }
 


### PR DESCRIPTION
Hotfix for https://github.com/hyphacoop/distributed-press-organizing/issues/169

Just gonna swallow resolve errors for now. Longer term we should delete missing accounts and do better caching.

Also added https://github.com/hyphacoop/distributed-press-organizing/issues/137 while I'm at it. Just the count not the items for now