### PR TITLE
fix: parse object.id in performUndo() and add tests

### DIFF
--- a/src/server/apsystem.test.ts
+++ b/src/server/apsystem.test.ts
@@ -216,9 +216,7 @@ test('ActivityPubSystem - List replies', async t => {
 })
 
 test('ActivityPubSystem - Undo activity', async t => {
-  const store = newStore()
-  const hookSystem = new HookSystem(store, mockFetch)
-  const aps = new ActivityPubSystem('http://localhost', store, mockModCheck, hookSystem, mockServer.log)
+  const { store, aps } = setupActivityPubSystem()
 
   const actorMention = '@user1@example.com'
   const inReplyTo = 'https://example.com/note2'

--- a/src/server/apsystem.ts
+++ b/src/server/apsystem.ts
@@ -456,9 +456,13 @@ export default class ActivityPubSystem {
   }
 
   async performUndo (fromActor: string, activity: APActivity): Promise<void> {
-    const { actor, object } = activity
+    const { actor } = activity
+    let object = activity.object
     if (typeof object !== 'string') {
-      throw createError(400, 'Undo must point to URL of object')
+      object = ((object != null) && 'id' in object && typeof object.id === 'string' && object.id) || undefined
+      if (typeof object !== 'string') {
+        throw createError(400, 'Undo must point to URL of object')
+      }
     }
     if (typeof actor !== 'string') {
       throw createError(400, 'Activities must contain an actor string')

--- a/src/server/apsystem.ts
+++ b/src/server/apsystem.ts
@@ -459,8 +459,9 @@ export default class ActivityPubSystem {
     const { actor } = activity
     let object = activity.object
     if (typeof object !== 'string') {
-      object = ((object != null) && 'id' in object && typeof object.id === 'string' && object.id) || undefined
-      if (typeof object !== 'string') {
+      if ((object != null) && 'id' in object && typeof object.id === 'string') {
+        object = object.id
+      } else {
         throw createError(400, 'Undo must point to URL of object')
       }
     }


### PR DESCRIPTION
Fixed issue https://github.com/hyphacoop/distributed-press-organizing/issues/150