### PR TITLE
fix: return empty string when request isn't signed #172

### DIFF
--- a/src/server/api/followers.ts
+++ b/src/server/api/followers.ts
@@ -1,5 +1,6 @@
 import { APCollection } from 'activitypub-types'
 import { Type } from '@sinclair/typebox'
+import createError from 'http-errors'
 
 import type { APIConfig, FastifyTypebox } from '.'
 import type Store from '../store'
@@ -22,7 +23,18 @@ export const followerRoutes = (cfg: APIConfig, store: Store, apsystem: ActivityP
     }
   }, async (request, reply) => {
     const { actor } = request.params
-    const allowed = await apsystem.hasPermissionActorRequest(actor, request)
+    let allowed : boolean
+
+    try {
+      allowed = await apsystem.hasPermissionActorRequest(actor, request)
+    } catch (e) {
+      if (createError.isHttpError(e) && e.name === 'UnauthorizedError') {
+        allowed = false
+      } else {
+        throw e
+      }
+    }
+
     const collection = await apsystem.followersCollection(actor, !allowed)
 
     return await reply.send(collection)

--- a/src/server/apsystem.ts
+++ b/src/server/apsystem.ts
@@ -95,7 +95,7 @@ export default class ActivityPubSystem {
     const { url, method, headers } = request
 
     if (headers.signature === undefined) {
-      return new Promise((resolve, reject) => resolve(""))
+      throw createError(401, 'Request is missing signature header', { fromActor, url, method })
     }
 
     const signature = signatureParser.parse({ url, method, headers })

--- a/src/server/apsystem.ts
+++ b/src/server/apsystem.ts
@@ -94,7 +94,7 @@ export default class ActivityPubSystem {
     // TODO: Fetch and verify Digest header
     const { url, method, headers } = request
 
-    if (!headers.signature) {
+    if (headers.signature === undefined) {
       return new Promise((resolve, reject) => resolve(""))
     }
 

--- a/src/server/apsystem.ts
+++ b/src/server/apsystem.ts
@@ -93,6 +93,11 @@ export default class ActivityPubSystem {
   async verifySignedRequest (request: FastifyRequest, fromActor?: string): Promise<string> {
     // TODO: Fetch and verify Digest header
     const { url, method, headers } = request
+
+    if (!headers.signature) {
+      return new Promise((resolve, reject) => resolve(""))
+    }
+
     const signature = signatureParser.parse({ url, method, headers })
     const { keyId } = signature
 


### PR DESCRIPTION
feels weird to do it like this, but i noticed the function throws an error when the signature header is missing, so any check that comes afterwards isn't reachable. for instance, now the followers collection can show totalItems when the request isn't signed, instead of the matchAll error (because activitypub-http-signatures doesn't check headers.signature is undefined).

the idea with the empty string is to return an actor that doesn't match anything, but being an empty string returned by a promise is what feels weird (and probably open to vulnerabiities)

ping @catdevnull, couldn't find you on the reviewers list