### PR TITLE
fix: for cosocial rename hs2019 signatures to rsa-256

### DIFF
--- a/src/client/index.test.ts
+++ b/src/client/index.test.ts
@@ -59,10 +59,10 @@ test('Actor Info Management', async t => {
   const mockActorInfo = { name: 'Test Actor', inbox: 'https://test.instance/inbox' }
 
   // Mock Fetch Actor Info
-  mockSignedFetch.withArgs(`${instance}/v1/testActor/`, sinon.match.any).resolves(new Response(JSON.stringify(mockActorInfo)))
+  mockSignedFetch.withArgs(`${instance}/v1/testActor`, sinon.match({ method: 'GET' })).resolves(new Response(JSON.stringify(mockActorInfo)))
 
   // Mock Delete Actor
-  mockSignedFetch.withArgs(`${instance}/v1/testActor/`, sinon.match({ method: 'DELETE' })).resolves(new Response())
+  mockSignedFetch.withArgs(`${instance}/v1/testActor`, sinon.match({ method: 'DELETE' })).resolves(new Response())
 
   const actorInfo = await client.getActorInfo('testActor')
   t.deepEqual(actorInfo, mockActorInfo)

--- a/src/server/apsystem.ts
+++ b/src/server/apsystem.ts
@@ -122,6 +122,11 @@ export default class ActivityPubSystem {
       })
     }
 
+    // Fix for cosocial
+    if (typeof headers.signature === 'string' && headers.signature.includes('hs2019')) {
+      headers.signature = headers.signature.replace('hs2019', 'rsa-sha256')
+    }
+
     const signature = signatureParser.parse({ url, method, headers })
     const { keyId } = signature
 


### PR DESCRIPTION
closes #92 